### PR TITLE
Improved code, removed redundant code

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,8 +1,8 @@
 name: CapsLimit
 version: 1.0.0
-api: 1.12.0
+api: 1.10.0
 main: CapsLimit\CapsLimit
-author: deot
+authors: [deot, Gamecrafter]
 # twitter: @deotern
 # Made by deot with <3
 

--- a/src/CapsLimit/CapsLimit.php
+++ b/src/CapsLimit/CapsLimit.php
@@ -32,6 +32,9 @@ class CapsLimit extends PluginBase implements Listener{
         $this->maxcaps = intval($this->getConfig()->get("max-caps"));
     }
     
+    /**
+     * @return string
+     */
     public function getPrefix(){
         return TextFormat::DARK_GREEN."[Caps".TextFormat::GREEN."Limit] ".TextFormat::WHITE;
     }
@@ -62,9 +65,7 @@ class CapsLimit extends PluginBase implements Listener{
     }
     
     /**
-     * @param PlayerChatEevnt $e
-     * @param array $args
-     * @return bool
+     * @param PlayerChatEevnt $event
      */
     public function onChat(PlayerChatEvent $event){
         $player = $event->getPlayer();

--- a/src/CapsLimit/CapsLimit.php
+++ b/src/CapsLimit/CapsLimit.php
@@ -18,27 +18,23 @@ use pocketmine\command\Command;
 use pocketmine\command\CommandSender;
 
 class CapsLimit extends PluginBase implements Listener{
-    
     /** @var int */
     private $maxcaps;
-    
     public function onEnable(){
+        $this->loadConfig();
         $this->getServer()->getPluginManager()->registerEvents($this, $this);
         $this->getLogger()->info($this->getPrefix()."Maximum caps limited to ".$this->getMaxCaps());
     }
-    
     public function loadConfig(){
         $this->saveDefaultConfig();
         $this->maxcaps = intval($this->getConfig()->get("max-caps"));
     }
-    
     /**
      * @return string
      */
     public function getPrefix(){
         return TextFormat::DARK_GREEN."[Caps".TextFormat::GREEN."Limit] ".TextFormat::WHITE;
     }
-    
     /**
      * @param CommandSender $sender
      * @param Command $command
@@ -63,7 +59,6 @@ class CapsLimit extends PluginBase implements Listener{
             $sender->sendMessage($this->getPrefix().TextFormat::RED."Value must be in positive numeric form");
             return false;
     }
-    
     /**
      * @param PlayerChatEevnt $event
      */
@@ -89,12 +84,10 @@ class CapsLimit extends PluginBase implements Listener{
     public function getMaxCaps(){
         return $this->maxcaps;
     }
-    
     public function saveConfig(){
         $this->getConfig()->set("max-caps", $this->getMaxCaps());
         $this->getConfig()->save();
     }
-    
     public function onDisable(){
         $this->saveConfig();
     }

--- a/src/CapsLimit/CapsLimit.php
+++ b/src/CapsLimit/CapsLimit.php
@@ -19,19 +19,17 @@ use pocketmine\command\CommandSender;
 
 class CapsLimit extends PluginBase implements Listener{
     
-    /** @var string */
+    /** @var int */
     private $maxcaps;
     
     public function onEnable(){
-        $this->loadConfig();
         $this->getServer()->getPluginManager()->registerEvents($this, $this);
         $this->getLogger()->info($this->getPrefix()."Maximum caps limited to ".$this->getMaxCaps());
     }
     
     public function loadConfig(){
-        @mkdir($this->getDataFolder());
         $this->saveDefaultConfig();
-        $this->maxcaps = $this->getConfig()->get("max-caps", "3");
+        $this->maxcaps = intval($this->getConfig()->get("max-caps"));
     }
     
     public function getPrefix(){
@@ -79,15 +77,13 @@ class CapsLimit extends PluginBase implements Listener{
             }
         }
             if ($count > $this->getMaxCaps()) {
-                $event->setCancelled();
+                $event->setCancelled(true);
                 $player->sendMessage(TextFormat::RED."You used too much caps!");
-                return;
             }
-            
     }
     
     /**
-     * @return string
+     * @return int
      */
     public function getMaxCaps(){
         return $this->maxcaps;
@@ -95,11 +91,10 @@ class CapsLimit extends PluginBase implements Listener{
     
     public function saveConfig(){
         $this->getConfig()->set("max-caps", $this->getMaxCaps());
-        parent::saveConfig();
+        $this->getConfig()->save();
     }
     
     public function onDisable(){
         $this->saveConfig();
     }
-
 }


### PR DESCRIPTION
Technically, this PR fixes some minor things, and also fixes the plugin's PHP docs. Also, this plugin is compatible with `1.10.0`, so you should put that instead of `1.12.0`. After all, you want as many people using your plugin as possible.
